### PR TITLE
Fixed the ports section within the Task 4.2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -713,7 +713,7 @@ services:
     networks:
       back-tier: null
     ports:
-      published: 3306
+    - published: 3306
       target: 3306
 
   dotnet-api:
@@ -725,7 +725,7 @@ services:
     networks:
       back-tier: null
     ports:
-      published: 57989
+    - published: 57989
       target: 80
 
   java-web:
@@ -738,7 +738,7 @@ services:
       back-tier:
       front-tier:
     ports:
-      published: 8080
+    - published: 8080
       target: 8080
 
 networks:


### PR DESCRIPTION
The deployment with Kubernetes using the docker compose configuration doesn't define the ports section as a list, which should be a list, by the spec.